### PR TITLE
Better dependency info and add Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,6 @@ RUN git clone https://github.com/GooFit/Minuit2.git && \
 #Compilation
 RUN git clone https://github.com/tweber-ill/ill_mirror-takin2-mnsi.git && \
 	cd /root/ill_mirror-takin2-mnsi/ext && ./setup_externals.sh && \
-	cd /root/ill_mirror-takin2-mnsi && make -j6
+	cd /root/ill_mirror-takin2-mnsi && make
 
 WORKDIR /root/ill_mirror-takin2-mnsi/bin

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:22.04
+WORKDIR /root
+
+#All build tools should be here (everyone usually already has these)
+RUN apt-get update && apt-get -y install wget unzip git build-essential cmake
+
+#Make sure that we have ALL dependencies
+##The following are often not available
+RUN apt-get --no-install-recommends -y install libboost-dev libboost-filesystem-dev libboost-program-options-dev libboost-iostreams-dev \
+	qtbase5-dev liblapacke-dev libpng-dev
+##Minuit2 is pretty much never available
+RUN git clone https://github.com/GooFit/Minuit2.git && \
+	mkdir Minuit2/build && cd Minuit2/build && \
+	cmake .. && make && make install
+
+#Compilation
+RUN git clone https://github.com/tweber-ill/ill_mirror-takin2-mnsi.git && \
+	cd /root/ill_mirror-takin2-mnsi/ext && ./setup_externals.sh && \
+	cd /root/ill_mirror-takin2-mnsi && make -j6
+
+WORKDIR /root/ill_mirror-takin2-mnsi/bin

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ The development repository can be found here:
 
 
 ## Dependencies
-This software depends on [*Takin*](https://doi.org/10.5281/zenodo.4117437) and the [*tlibs* libraries](https://doi.org/10.5281/zenodo.5717779).
+This software depends on [*Takin*](https://doi.org/10.5281/zenodo.4117437), the [*tlibs* libraries](https://doi.org/10.5281/zenodo.5717779), Minuit2 and some basic libs.
 An archived copy of their source codes are included in the directory ext/.
 Furthermore, their repositories are available here:
 - Stable releases: https://github.com/t-weber/takin2
@@ -30,6 +30,9 @@ Furthermore, their repositories are available here:
 - Build the module: `make -j4`.
 - Copy the built plugin modules to *Takin's* plugin directory: `mkdir -pv ~/.takin/plugins/ && cp -v lib/*.so ~/.takin/plugins/`
 - The helper tools can be found in the bin/ directory.
+
+See the included `Dockerfile` for more compilation info.
+This can also be used to compile it in a dockerimage with `docker build -t takin2-msni .` if you have buildproblems.
 
 
 ## References and Acknowledgements
@@ -56,3 +59,5 @@ The helimagnon and ferromagnetic parts of this code have been used in the follow
 
 The skyrmion part of this code has been used in the following paper:
 - T. Weber, D. M. Fobes, J. Waizner, P. Steffens, G. S. Tucker, M. Böhm, L. Beddrich, C. Franz, H. Gabold, R. Bewley, D. Voneshen, M. Skoulatos, R. Georgii, G. Ehlers, A. Bauer, C. Pfleiderer, P. Böni, M. Janoschek, and M. Garst, Science **375**(6584), pp. 1025-1030, https://doi.org/10.1126/science.abe4441 (2022).
+
+Completion of dependencies and Docker build info: N. Garofil, Universiteit Antwerpen


### PR DESCRIPTION
I (ICT) had to help a colleague (Physics) that didn't manage to build your code on his PC.
Because he was missing a lot of dependencies.

This PR:
- Adds a bit extra info about the deps in `README.md` to help users build it.
- Adds a `Dockerfile` that:
  - Shows how to build the code on a system that doesn't have all the deps yet
  - Can be used to build a image on every possible system _(that has docker)_
  - Can be used to run it in a container on every possible system _(that has docker)_

**NOTE:**<br> I am a sysadmin, not a physicist.<br>Although I can proof that this fixes all possible compile errors, I do not know if it behaves correctly.<br>Try it and/or read the Dockerfile and contact me if other things are needed for correct usage.